### PR TITLE
Update tsconfig.json for Typescript 1.6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.6.0",
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
@@ -14,7 +14,7 @@
     "outDir": "dist"
   },
   "files": [
-    "node_modules/typescript/bin/lib.dom.d.ts",
+    "node_modules/typescript/lib/lib.dom.d.ts",
     "src/typings/_custom.d.ts",
     "src/app/components/app.ts",
     "src/app/bootstrap.ts"


### PR DESCRIPTION
Update the version of the tsconfig.json to match the TypeScript version
in package.json and fixes the path to lib.dom.d.ts which moved as of TS
version 1.6

This fixes annoying red squiggly line errors in visual studio code (and potentially
other editors) relating to module, experimentalDecorators or emitDecoratorMetadata
not being set.