### PR TITLE
Fix Protractor/Selenium Configuration

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -1,7 +1,7 @@
 // @AngularClass
 
 exports.config = {
-  baseUrl: 'http://localhost:8080/',
+  baseUrl: 'http://localhost:3000/',
 
   allScriptsTimeout: 11000,
 
@@ -19,7 +19,7 @@ exports.config = {
     }
   },
 
-  seleniumAddress: 'http://localhost:4444/wd/hub',
+  seleniumServerJar: './node_modules/protractor/selenium/selenium-server-standalone-2.45.0.jar',
 
   specs: [
     'test/**/*.e2e.js'


### PR DESCRIPTION
To get e2e tests running, I had to fix some issues with Protractor/Selenium. First of all I had to adjust the port of the `baseUrl` to `3000` since the webpack dev server is running on this port. 

Then I ran into an issue in which it was impossible to get the WebDriver session started. This is documented [here](https://github.com/angular/angular-seed/issues/251). The [solution](https://github.com/angular/angular-seed/issues/251#issuecomment-129217595) by @josefsalyer worked for me, so I suggest to use it in this repo as well.