### PR TITLE
Add typedoc support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ Thumbs.db
 __build__/**
 .webpack.json
 
+#doc
+/doc
 
 # IDE #
 .idea/
+*.swp

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "karma start",
     "remove-tsd-loader-typings": "rimraf node_modules/typescript-simple-loader/typescript-simple-loader.d.ts",
     "tsd-update": "npm run remove-tsd-loader-typings && tsd reinstall --overwrite",
+    "docs": "typedoc  --options typedoc.json  src/**/*.ts",
     "postinstall": "npm run tsd-update && tsd install && tsd link",
     "prestart": "npm install",
     "start": "npm run server"
@@ -62,6 +63,7 @@
     "rimraf": "^2.4.3",
     "style-loader": "^0.12.2",
     "tsd": "^0.6.4",
+    "typedoc": "^0.3.11",
     "typescript": "^1.6.2",
     "typescript-simple-loader": "^0.3.7",
     "url-loader": "^0.5.5",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,16 @@
+{
+	"mode"  	: "modules", 			
+	"out"   	: "doc",
+	"theme" 	: "default",
+		
+	"ignoreCompilerErrors" 		: "true",
+	"experimentalDecorators"	: "true",
+        "emitDecoratorMetadata"		: "true",
+	"target"			: "ES5",
+	"moduleResolution"		: "node",
+	"preserveConstEnums"		: "true",
+	"stripInternal"			: "true",
+	"suppressExcessPropertyErrors"	: "true",
+	"suppressImplicitAnyIndexErrors": "true",
+	"module"			: "commonjs"
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,7 +5,7 @@
 		
 	"ignoreCompilerErrors" 		: "true",
 	"experimentalDecorators"	: "true",
-        "emitDecoratorMetadata"		: "true",
+	"emitDecoratorMetadata"		: "true",
 	"target"			: "ES5",
 	"moduleResolution"		: "node",
 	"preserveConstEnums"		: "true",


### PR DESCRIPTION
This PR adds typedoc support for the src/* folder.

It does spit out some errors due to duplicate symbols on some of the angular2 imports (Promise amongst others), but it will parse and process the src folder just fine.

