### PR TITLE
Refactor for correct reference to Rx module

### DIFF
--- a/examples/rx-autosuggest/bootstrap.ts
+++ b/examples/rx-autosuggest/bootstrap.ts
@@ -5,7 +5,7 @@ import {bootstrap} from 'angular2/angular2';
 
 import {FORM_BINDINGS} from 'angular2/angular2'
 import {ROUTER_BINDINGS} from 'angular2/router';
-import {ELEMENT_PROBE_BINDINGS} from 'angular2/debug';
+import {ELEMENT_PROBE_BINDINGS} from 'angular2/angular2';
 import {HTTP_BINDINGS} from 'angular2/http';
 
 import {App} from './app';

--- a/examples/rx-autosuggest/directives/ac-autosuggest.ts
+++ b/examples/rx-autosuggest/directives/ac-autosuggest.ts
@@ -3,8 +3,10 @@
 // Angular 2
 import {Directive, View, EventEmitter, ElementRef} from 'angular2/angular2';
 
+import  zone from ;
+
 // RxJs
-import * as Rx from 'rx';
+import * as Rx from '@reactivex/rxjs';
 
 import {GithubService} from '../services/GithubService';
 

--- a/examples/rx-autosuggest/services/GithubService.ts
+++ b/examples/rx-autosuggest/services/GithubService.ts
@@ -2,7 +2,7 @@
 
 import {Injectable} from 'angular2/angular2';
 import {Http} from 'angular2/http';
-import * as Rx from 'rx';
+import * as Rx from '@reactivex/rxjs';
 
 
 @Injectable()

--- a/examples/rx-timeflies/components/timeflies.ts
+++ b/examples/rx-timeflies/components/timeflies.ts
@@ -6,7 +6,7 @@ import {Component, View, ElementRef, NgZone, CORE_DIRECTIVES} from 'angular2/ang
 // Services
 import {MESSAGE_BINDINGS, Message} from '../services/Message';
 
-import * as Rx from 'rx';
+import * as Rx from '@reactiveX/rxjs';
 
 interface LetterConfig {
   text: string;


### PR DESCRIPTION
Original examples had
```javascript
import * as Rx from 'rx'
```

This should have been

```javascript
import * as Rx from '@reactivex/rxjs'
```