### PR TITLE
Fix: examples/large-app

### DIFF
--- a/examples/large-app/bootstrap.ts
+++ b/examples/large-app/bootstrap.ts
@@ -22,9 +22,9 @@ import {bootstrap} from 'angular2/angular2';
 /*
  * Angular Modules
  */
-import {HTTP_BINDINGS, } from 'angular2/http';
-import {FORM_BINDINGS} from 'angular2/src/core/forms'
-import {ROUTER_BINDINGS} from 'angular2/router';
+import {FORM_PROVIDERS} from 'angular2/angular2';
+import {HTTP_PROVIDERS} from 'angular2/http';
+import {ROUTER_PROVIDERS} from 'angular2/router';
 
 /*
  * App Services
@@ -45,9 +45,9 @@ import {App} from './components/app';
  */
 const UNIVERSAL_BINDINGS = [
   // Angular's http/form/router services/bindings
-  HTTP_BINDINGS,
-  FORM_BINDINGS,
-  ROUTER_BINDINGS,
+  HTTP_PROVIDERS,
+  FORM_PROVIDERS,
+  ROUTER_PROVIDERS,
 
   // Our collection of services from /services
   APP_SERVICES_BINDINGS

--- a/examples/large-app/components/app.ts
+++ b/examples/large-app/components/app.ts
@@ -56,16 +56,16 @@ const APP_STYLES = require('./app.css');
         <span class="logo">{{ name | capitalize }} + Webpack</span>
         <ul>
           <li class="l-left">
-            <a [router-link]=" ['/home'] "class="top-nav-button ac-default-theme">Home</a>
+            <a [router-link]=" ['/Home'] " class="top-nav-button ac-default-theme">Home</a>
           </li>
           <li class="l-left">
-            <a [router-link]=" ['/dashboard'] "class="top-nav-button ac-default-theme">Dashboard</a>
+            <a [router-link]=" ['/Dashboard'] " class="top-nav-button ac-default-theme">Dashboard</a>
           </li>
           <li class="l-left">
-            <a [router-link]=" ['/todo'] "class="top-nav-button ac-default-theme">Todo</a>
+            <a [router-link]=" ['/Todo'] " class="top-nav-button ac-default-theme">Todo</a>
           </li>
           <li class="l-left">
-            <a [router-link]=" ['/rxjs-examples', 'search'] "class="top-nav-button ac-default-theme">RxJs Examples</a>
+            <a [router-link]=" ['/RxjsExamples', 'Search'] " class="top-nav-button ac-default-theme">RxJs Examples</a>
           </li>
         </ul>
       </div>
@@ -81,10 +81,10 @@ const APP_STYLES = require('./app.css');
   `
 })
 @RouteConfig([
-  { path: '/',                  as: 'home',          component: Home },
-  { path: '/dashboard',         as: 'dashboard',     component: Dashboard },
-  { path: '/todo',              as: 'todo',          component: Todo },
-  { path: '/rxjs-examples/...', as: 'rxjs-examples', component: RxJsExamples }
+  { path: '/',                  as: 'Home',          component: Home },
+  { path: '/dashboard',         as: 'Dashboard',     component: Dashboard },
+  { path: '/todo',              as: 'Todo',          component: Todo },
+  { path: '/rxjs-examples/...', as: 'RxjsExamples', component: RxJsExamples }
 ])
 export class App {
   name: string;

--- a/examples/large-app/components/rxjs_examples/rxjs-examples.ts
+++ b/examples/large-app/components/rxjs_examples/rxjs-examples.ts
@@ -1,28 +1,27 @@
 /// <reference path="../../../typings/_custom.d.ts" />
 
 // Angular 2
-import {Component, View} from 'angular2/angular2';
+import {Component, View, NgClass } from 'angular2/angular2';
 import {RouteConfig, ROUTER_DIRECTIVES} from 'angular2/router';
 
 import {SearchGithub} from '../../../rx-autosuggest/components/search-github';
-//import {Timeflies} from './timeflies/timeflies';
-//import {Tictactoe} from './tictactoe/tictactoe';
-//import {DraggableDiv} from './draggable_div/draggable_div';
-
+import {Timeflies} from '../../../rx-timeflies/components/timeflies';
+import {Tictactoe} from '../../../game-tictactoe/components/tictactoe';
+//import {DragElement} from '../../../rx-draggable/components/drag-element';
 
 
 @Component({
   selector: 'rxjs-examples'
 })
 @RouteConfig([
-  { path: '/',              redirectTo: '/search' }//,
-  //{ path: '/search',        as: 'search',        component: Search },
-  //{ path: '/timeflies',     as: 'timeflies',     component: Timeflies },
-  //{ path: '/tictactoe',     as: 'tictactoe',     component: Tictactoe },
-  //{ path: '/draggable_div', as: 'draggable_div', component: DraggableDiv }
+  { path: '/',              redirectTo: '/search' },
+  { path: '/search',        as: 'Search',        component: SearchGithub},
+  { path: '/timeflies',     as: 'Timeflies',     component: Timeflies },
+  { path: '/tictactoe',     as: 'Tictactoe',     component: Tictactoe },
+  //{ path: '/draggable',     as: 'Draggable',     component: DragElement}
 ])
 @View({
-  //directives: [ ROUTER_DIRECTIVES, CSSClass ],
+  directives: [ ROUTER_DIRECTIVES, NgClass ],
   // include our .css file
   styles: [
     // Use webpack's `require` to get files as a raw string using raw-loader
@@ -34,7 +33,7 @@ import {SearchGithub} from '../../../rx-autosuggest/components/search-github';
       <ul class="rxjs-menu">
         <li>
           <a class="ac-button ac-default-theme"
-             [router-link]=" ['./search'] "
+             [router-link]=" ['./Search'] "
              (click)="active = 0"
              [class.active]="active === 0">
             Search Github
@@ -42,22 +41,22 @@ import {SearchGithub} from '../../../rx-autosuggest/components/search-github';
         </li>
         <li>
           <a class="ac-button md-default-theme"
-             [router-link]=" ['./timeflies'] "
+             [router-link]=" ['./Timeflies'] "
              (click)="active = 1"
              [class.active]="active === 1">Timeflies</a>
         </li>
         <li>
           <a class="ac-button md-default-theme"
-             [router-link]=" ['./tictactoe'] "
+             [router-link]=" ['./Tictactoe'] "
              (click)="active = 2"
              [class.active]="active === 2">Tic tac toe</a>
         </li>
-        <li>
-          <a class="ac-button md-default-theme"
-             [router-link]=" ['./draggable_div'] "
-             (click)="active = 3"
-             [class.active]="active === 3">Drag Element</a>
-        </li>
+        <!--<li>-->
+          <!--<a class="ac-button md-default-theme"-->
+             <!--[router-link]=" ['./Draggable'] "-->
+             <!--(click)="active = 3"-->
+             <!--[class.active]="active === 3">Drag Element</a>-->
+        <!--</li>-->
       </ul>
     </nav>
 

--- a/examples/large-app/pipes/RxPipe.ts
+++ b/examples/large-app/pipes/RxPipe.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../typings/_custom.d.ts" />
 import {Pipe, ChangeDetectorRef} from 'angular2/angular2';
-import {AsyncPipe} from "angular2/angular2";
+import {AsyncPipe, Observable} from "angular2/angular2";
 import * as Rx from '@reactivex/rxjs';
 
 export function isObservable(obs) {
@@ -36,7 +36,7 @@ export class RxPipe extends AsyncPipe {
     return isObservable(obs);
   }
 
-  _selectStrategy(obj: Rx.Observable<any>) {
+  _selectStrategy(obj: Observable | Promise<any>) {
     return RX_STRATEGY;
   }
 

--- a/examples/rx-timeflies/components/timeflies.ts
+++ b/examples/rx-timeflies/components/timeflies.ts
@@ -6,7 +6,7 @@ import {Component, View, ElementRef, NgZone, CORE_DIRECTIVES} from 'angular2/ang
 // Services
 import {MESSAGE_BINDINGS, Message} from '../services/Message';
 
-import * as Rx from '@reactiveX/rxjs';
+import * as Rx from '@reactivex/rxjs';
 
 interface LetterConfig {
   text: string;


### PR DESCRIPTION
I have fixed several issues with angular2@2.0.0-alpha.44. Furthermore I have fixed a broken import (see https://github.com/angular-class/angular2-webpack-starter/commit/a49383969f3729a73b1ac067c41e253b95556d53#commitcomment-13901195).

I also changed an import statement to keep the syntax the same across the application, because webpack complained about the import: 
> There is another module with an equal name when case is ignored.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Rename module if multiple modules are expected or use equal casing if one module is expected.

There are still some issues with the 'search github' and 'todo' components, but the router does work again and at least webpack compiles without an error. This PR fixes https://github.com/angular-class/angular2-webpack-starter/issues/92.