### PR TITLE
Fix broken rx-autosuggest example

### DIFF
--- a/examples/rx-autosuggest/directives/ac-autosuggest.ts
+++ b/examples/rx-autosuggest/directives/ac-autosuggest.ts
@@ -3,16 +3,16 @@
 // Angular 2
 import {Directive, View, EventEmitter, ElementRef} from 'angular2/angular2';
 
-import  zone from ;
-
 // RxJs
 import * as Rx from '@reactivex/rxjs';
 
 import {GithubService} from '../services/GithubService';
 
+declare var zone: Zone;
+
 @Directive({
   selector: 'input[type=text][ac-autosuggest-github]',
-  events:   [ 'results', 'loading' ],
+  outputs: [ 'results', 'loading' ],
   bindings: [ GithubService ]
 })
 export class AcAutosuggestGithub {
@@ -26,13 +26,13 @@ export class AcAutosuggestGithub {
   // Lifecycle hook
   onInit() {
 
-    (<any>Rx).Observable.fromEvent(this.el.nativeElement, 'input')
+    (<any>Rx).Observable.fromEvent(this.el.nativeElement, 'keyup')
       .map(e => e.target.value)                  // Project the text from the input
       .filter(text => text.length > 2)           // Only if the text is longer than 2 characters
-      .debounce(250)                             // Pause for 250ms
+      .debounceTime(250)                         // Pause for 250ms
       .distinctUntilChanged()                    // Only if the value has changed
       .do(zone.bind(() => this.loading.next(true)))
-      .flatMapLatest(query => this.github.search(query)) // send query to search service
+      .flatMap(query => this.github.search(query)) // send query to search service
       .do(zone.bind(() => this.loading.next(false)))
       // here is the real action
       .subscribe(

--- a/examples/rx-autosuggest/services/GithubService.ts
+++ b/examples/rx-autosuggest/services/GithubService.ts
@@ -17,7 +17,6 @@ export class GithubService {
    */
   search(query: string): Rx.Observable<any[]> {
     return this.http.get(this.url + query)
-      .toRx()                  // convert it to pure Rx stream
       .map(res => res.json())  // make json
       .map(res => res.items)   // extract "items" only
       .filter(repos => repos); // only if there are results


### PR DESCRIPTION
I have fixed the rx-autosuggest example which was broken when using angular2@2.0.0-alpha.44. The example is now working again.