### PR TITLE
chore(rx-examples): Rename BINDINGS to PROVIDERS in rx-examples

### DIFF
--- a/examples/rx-autosuggest/app.ts
+++ b/examples/rx-autosuggest/app.ts
@@ -1,7 +1,7 @@
 /// <reference path="../typings/_custom.d.ts" />
 
 // Angular 2
-import {Component, View} from 'angular2/angular2';
+import {Component} from 'angular2/angular2';
 
 import {SearchGithub} from './components/search-github';
 
@@ -10,9 +10,7 @@ import {SearchGithub} from './components/search-github';
  * our top level component that holds all of our components
  */
 @Component({
-  selector: 'app'
-})
-@View({
+  selector: 'app',
   directives: [ SearchGithub ],
   template: `
   <main>

--- a/examples/rx-autosuggest/bootstrap.ts
+++ b/examples/rx-autosuggest/bootstrap.ts
@@ -3,20 +3,19 @@
 // Angular 2
 import {bootstrap} from 'angular2/angular2';
 
-import {FORM_BINDINGS} from 'angular2/angular2'
-import {ROUTER_BINDINGS} from 'angular2/router';
-import {ELEMENT_PROBE_BINDINGS} from 'angular2/angular2';
-import {HTTP_BINDINGS} from 'angular2/http';
+import {FORM_PROVIDERS, ELEMENT_PROBE_PROVIDERS} from 'angular2/angular2'
+import {ROUTER_PROVIDERS} from 'angular2/router';
+import {HTTP_PROVIDERS} from 'angular2/http';
 
 import {App} from './app';
 
 
-const APP_BINDINGS = [
+const APP_PROVIDERS = [
   // These are dependencies of our App
-  FORM_BINDINGS,
-  ROUTER_BINDINGS,
-  HTTP_BINDINGS,
-  ELEMENT_PROBE_BINDINGS
+  FORM_PROVIDERS,
+  ROUTER_PROVIDERS,
+  HTTP_PROVIDERS,
+  ELEMENT_PROBE_PROVIDERS
 ];
 /*
  * Bootstrap our Angular app with a top level component `App` and inject
@@ -25,6 +24,6 @@ const APP_BINDINGS = [
 bootstrap(
   // Top Level Component
   App,
-  // AppBindings
-  APP_BINDINGS
+  // AppProviders
+  APP_PROVIDERS
 );

--- a/examples/rx-autosuggest/components/search-github.ts
+++ b/examples/rx-autosuggest/components/search-github.ts
@@ -1,15 +1,13 @@
 /// <reference path="../../typings/_custom.d.ts" />
 
 // Angular 2
-import {Component, View} from 'angular2/angular2';
+import {Component} from 'angular2/angular2';
 import {CORE_DIRECTIVES, FORM_DIRECTIVES} from 'angular2/angular2';
 
 import {AcAutosuggestGithub} from '../directives/ac-autosuggest';
 
 @Component({
-  selector: 'search-github'
-})
-@View({
+  selector: 'search-github',
   directives: [ CORE_DIRECTIVES, FORM_DIRECTIVES, AcAutosuggestGithub ],
   template: `
   <div style="padding: 0 16px;">

--- a/examples/rx-autosuggest/directives/ac-autosuggest.ts
+++ b/examples/rx-autosuggest/directives/ac-autosuggest.ts
@@ -16,7 +16,7 @@ declare var zone: Zone;
 @Directive({
   selector: 'input[type=text][ac-autosuggest-github]',
   outputs: [ 'results', 'loading' ],
-  bindings: [ GithubService ]
+  providers: [ GithubService ]
 })
 export class AcAutosuggestGithub {
   results: EventEmitter = new EventEmitter();

--- a/examples/rx-autosuggest/services/GithubService.ts
+++ b/examples/rx-autosuggest/services/GithubService.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../typings/_custom.d.ts" />
 
-import {Injectable} from 'angular2/angular2';
+import {provide, Injectable} from 'angular2/angular2';
 import {Http} from 'angular2/http';
 import * as Rx from '@reactivex/rxjs';
 
@@ -23,6 +23,6 @@ export class GithubService {
   }
 }
 
-export const GITHUB_BINDINGS = [
-  GithubService
+export var GITHUB_PROVIDERS: Array<any> = [
+  provide(GithubService, {useClass: GithubService})
 ];

--- a/examples/rx-draggable/bootstrap.ts
+++ b/examples/rx-draggable/bootstrap.ts
@@ -3,19 +3,19 @@
 // Angular 2
 import {bootstrap} from 'angular2/angular2';
 
-import {FORM_BINDINGS, ELEMENT_PROBE_BINDINGS} from 'angular2/angular2'
-import {ROUTER_BINDINGS} from 'angular2/router';
-import {HTTP_BINDINGS} from 'angular2/http';
+import {FORM_PROVIDERS, ELEMENT_PROBE_PROVIDERS} from 'angular2/angular2'
+import {ROUTER_PROVIDERS} from 'angular2/router';
+import {HTTP_PROVIDERS} from 'angular2/http';
 
 import {App} from './app';
 
 
-const APP_BINDINGS = [
+const APP_PROVIDERS = [
   // These are dependencies of our App
-  FORM_BINDINGS,
-  ROUTER_BINDINGS,
-  HTTP_BINDINGS,
-  ELEMENT_PROBE_BINDINGS
+  FORM_PROVIDERS,
+  ROUTER_PROVIDERS,
+  HTTP_PROVIDERS,
+  ELEMENT_PROBE_PROVIDERS
 ];
 /*
  * Bootstrap our Angular app with a top level component `App` and inject
@@ -24,6 +24,6 @@ const APP_BINDINGS = [
 bootstrap(
   // Top Level Component
   App,
-  // AppBindings
-  APP_BINDINGS
+  // AppProviders
+  APP_PROVIDERS
 );

--- a/examples/rx-draggable/components/drag-element.ts
+++ b/examples/rx-draggable/components/drag-element.ts
@@ -7,10 +7,7 @@ import {Component, View} from 'angular2/angular2';
 import {Draggable} from '../directives/draggable';
 
 @Component({
-  selector: 'drag-element'
-})
-@View({
-  // needed in order to tell Angular's compiler what's in the template
+  selector: 'drag-element',
   directives: [ Draggable ],
   styles: [`
     [draggable] {

--- a/examples/rx-timeflies/app.ts
+++ b/examples/rx-timeflies/app.ts
@@ -1,7 +1,7 @@
 /// <reference path="../typings/_custom.d.ts" />
 
 // Angular 2
-import {Component, View} from 'angular2/angular2';
+import {Component} from 'angular2/angular2';
 
 import {Timeflies} from './components/timeflies';
 
@@ -10,9 +10,7 @@ import {Timeflies} from './components/timeflies';
  * our top level component that holds all of our components
  */
 @Component({
-  selector: 'app'
-})
-@View({
+  selector: 'app',
   directives: [ Timeflies ],
   template: `
   <main>

--- a/examples/rx-timeflies/bootstrap.ts
+++ b/examples/rx-timeflies/bootstrap.ts
@@ -3,19 +3,19 @@
 // Angular 2
 import {bootstrap} from 'angular2/angular2';
 
-import {FORM_BINDINGS, ELEMENT_PROBE_BINDINGS} from 'angular2/angular2'
-import {ROUTER_BINDINGS} from 'angular2/router';
-import {HTTP_BINDINGS} from 'angular2/http';
+import {FORM_PROVIDERS, ELEMENT_PROBE_PROVIDERS} from 'angular2/angular2'
+import {ROUTER_PROVIDERS} from 'angular2/router';
+import {HTTP_PROVIDERS} from 'angular2/http';
 
 import {App} from './app';
 
 
-const APP_BINDINGS = [
+const APP_PROVIDERS = [
   // These are dependencies of our App
-  FORM_BINDINGS,
-  ROUTER_BINDINGS,
-  HTTP_BINDINGS,
-  ELEMENT_PROBE_BINDINGS
+  FORM_PROVIDERS,
+  ROUTER_PROVIDERS,
+  HTTP_PROVIDERS,
+  ELEMENT_PROBE_PROVIDERS
 ];
 /*
  * Bootstrap our Angular app with a top level component `App` and inject
@@ -24,6 +24,6 @@ const APP_BINDINGS = [
 bootstrap(
   // Top Level Component
   App,
-  // AppBindings
-  APP_BINDINGS
+  // AppProviders
+  APP_PROVIDERS
 );

--- a/examples/rx-timeflies/components/timeflies.ts
+++ b/examples/rx-timeflies/components/timeflies.ts
@@ -1,10 +1,10 @@
 /// <reference path="../../typings/_custom.d.ts" />
 
 // Angular 2
-import {Component, View, ElementRef, NgZone, CORE_DIRECTIVES} from 'angular2/angular2';
+import {Component, ElementRef, NgZone, CORE_DIRECTIVES} from 'angular2/angular2';
 
 // Services
-import {MESSAGE_BINDINGS, Message} from '../services/Message';
+import {MESSAGE_PROVIDERS, Message} from '../services/Message';
 
 import * as Rx from '@reactivex/rxjs';
 
@@ -17,9 +17,7 @@ interface LetterConfig {
 
 @Component({
   selector: 'timeflies',
-  bindings: [ MESSAGE_BINDINGS ]
-})
-@View({
+  providers: [ MESSAGE_PROVIDERS ],
   directives: [ CORE_DIRECTIVES ],
   template: `
   <div style="background-color: papayawhip; height: 500px;">

--- a/examples/rx-timeflies/services/Message.ts
+++ b/examples/rx-timeflies/services/Message.ts
@@ -1,5 +1,5 @@
 /// <reference path="../../typings/_custom.d.ts" />
-import {bind, Injectable} from 'angular2/angular2';
+import {provide, Injectable} from 'angular2/angular2';
 
 @Injectable()
 export class Message {
@@ -12,6 +12,6 @@ export class Message {
 }
 
 
-export var MESSAGE_BINDINGS: Array<any> = [
-  bind(Message).toClass(Message)
+export var MESSAGE_PROVIDERS: Array<any> = [
+  provide(Message, {useClass: Message})
 ];


### PR DESCRIPTION
BINDINGS will be deprecated soon, so we use PROVIDERS instead. Also remove unnecessary @View